### PR TITLE
Property Tests for Numbers

### DIFF
--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -28,9 +28,6 @@ integerGen :: Gen Text
 integerGen = Text.pack . show <$>
       (Gen.integral $ Range.exponential 1 (10^309))
 
-expGen :: Gen Text
-expGen = Text.pack . show <$>
-  (Gen.integral (Range.linearFrom 0 (-10^16) (10^16)))
 
 decBefore :: Gen Text
 decBefore = Gen.constant "." <> integerGen
@@ -45,8 +42,10 @@ numberGen = signGen' <> integerGen
 scientificNumberGen :: Gen Text
 scientificNumberGen = base <> e <> signGen <> expGen
   where
-    base = Text.singleton <$> Gen.element ['0'..'9']
+    base = Gen.choice [numberGen, fractionalGen]
     e = Gen.element ["e", "E"]
+    expGen = Text.pack . show <$>
+      (Gen.integral (Range.linearFrom 0 (-10^16) (10^16)))
 
 fractionalGen :: Gen Text
 fractionalGen = integerGen <> Gen.constant "." <> integerGen

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -16,20 +16,26 @@ import qualified Hedgehog.Range as Range
 -- DISCREPANCY: 'jq' allows both 000 in input and its own number literals,
 -- but JSON spec does not. We'll stay closest to 'jq' by doing this, too.
 
+integer :: Integer -> Gen Text
+integer limit = Text.pack . show <$>
+      (Gen.integral $ Range.constant 0 limit)
+
 -- First, an unsized Gen of JSON numbers.
 
 numberGen :: Gen Text
-numberGen = sign <> integer
+numberGen = sign <> number
   where
     sign = Gen.element ["", "-"]
-    integer = Text.singleton <$> Gen.element ['0'..'9']
+    number = integer $ 2^52
 
-
--- Second, a sized one.
-
-sizedNumberGen :: Gen Text
-sizedNumberGen = undefined
-
--- Third, a scientific notation
+-- Second, a scientific notation
 scientificNumberGen :: Gen Text
-scientificNumberGen = undefined
+scientificNumberGen = base <> e <> exponent
+  where
+    base = Text.singleton <$> Gen.element ['0'..'9']
+    e = Gen.constant "e"
+    exponent = integer $ 10^15
+
+
+jsonNumberGen :: Gen Text
+jsonNumberGen = Gen.choice [numberGen, scientificNumberGen]

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -19,10 +19,10 @@ import qualified Hedgehog.Range as Range
 
 -- | Helper Generators
 signGen :: Gen Text
-signGen = Gen.element ["+", "-", ""]
+signGen = Gen.element ["", "+", "-"]
 
 signGen' :: Gen Text
-signGen' = Gen.element ["-", ""]
+signGen' = Gen.element ["", "-"]
 
 integerGen :: Gen Text
 integerGen = Text.pack . show <$>
@@ -42,13 +42,13 @@ numberGen = signGen' <> integerGen
 scientificNumberGen :: Gen Text
 scientificNumberGen = base <> e <> signGen <> expGen
   where
-    base = Gen.choice [numberGen, fractionalGen]
+    base = Gen.choice [numberGen, fractionalGen, optFractionalGen]
     e = Gen.element ["e", "E"]
     expGen = Text.pack . show <$>
       (Gen.integral (Range.linearFrom 0 (-10^16) (10^16)))
 
 fractionalGen :: Gen Text
-fractionalGen = integerGen <> Gen.constant "." <> integerGen
+fractionalGen = signGen' <> integerGen <> Gen.constant "." <> integerGen
 
 optFractionalGen :: Gen Text
 optFractionalGen = signGen' <> Gen.choice [decBefore, decAfter]

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -19,13 +19,17 @@ import qualified Hedgehog.Range as Range
 -- First, an unsized Gen of JSON numbers.
 
 numberGen :: Gen Text
-numberGen = sign <> integer <> commaPart
+numberGen = sign <> integer
   where
     sign = Gen.element ["", "-"]
     integer = Text.singleton <$> Gen.element ['0'..'9']
-    commaPart = Gen.element [ "..." ]
+
 
 -- Second, a sized one.
 
 sizedNumberGen :: Gen Text
 sizedNumberGen = undefined
+
+-- Third, a scientific notation
+scientificNumberGen :: Gen Text
+scientificNumberGen = undefined

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -165,12 +165,18 @@ spec_StrLit = do
 hprop_NumLit :: Property
 hprop_NumLit = property $ do
   genNum <- forAll $ numberGen
-  let parsed = parseExpr genNum
-  case parsed of
-    Left _ -> failure
-    Right jqNum -> case fmap NumLit (readMaybe $ Text.unpack genNum) of
-                    Nothing -> failure
-                    Just haskNum -> jqNum === haskNum
+
+  let nums = do
+        jqNum <- eTm $ parseExpr genNum
+        haskNum <- fmap NumLit (readMaybe $ Text.unpack genNum)
+        pure (jqNum, haskNum)
+
+  case nums of
+    Nothing -> failure
+    Just (j,h) -> j === h
+  where
+    eTm = either (const Nothing) Just
+
 
 spec_NumLit :: Spec
 spec_NumLit = do

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -7,7 +7,6 @@ import           Data.Char (chr)
 import           Data.Foldable (for_)
 import qualified Data.Text as Text
 import           Data.Text (Text)
-import           Data.Text.Encoding (decodeUtf8)
 import           Data.Void
 
 import           Hedgehog hiding (Var)

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -5,8 +5,6 @@ module ParserTest where
 
 import           Data.Char (chr)
 import           Data.Foldable (for_)
-import           Data.Maybe
-import           Data.Scientific
 import qualified Data.Text as Text
 import           Data.Text (Text)
 import           Data.Text.Encoding (decodeUtf8)
@@ -14,11 +12,10 @@ import           Data.Void
 
 import           Hedgehog hiding (Var)
 import           Test.Hspec.Megaparsec
-import           Text.Megaparsec (parse, ParseErrorBundle(..))
+import           Text.Megaparsec (parse, ParseErrorBundle)
 import           Text.RawString.QQ
 import           Text.Read
 import           Test.Tasty.Hspec
-import           Test.Tasty.Hedgehog
 
 import           Data.Aeson.Jq.Expr
 import           Data.Aeson.Jq.Parser

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -163,7 +163,7 @@ spec_StrLit = do
 
 hprop_NumLit :: Property
 hprop_NumLit = property $ do
-  genNum <- forAll $ numberGen
+  genNum <- forAll $ jsonNumberGen
 
   let nums = do
         jqNum <- eTm $ parseExpr genNum
@@ -175,7 +175,6 @@ hprop_NumLit = property $ do
     Just (j,h) -> j === h
   where
     eTm = either (const Nothing) Just
-
 
 spec_NumLit :: Spec
 spec_NumLit = do

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -16,8 +16,8 @@ import           Text.RawString.QQ
 import           Text.Read
 import           Test.Tasty.Hspec
 
-import           Data.Aeson.Jq.Expr
-import           Data.Aeson.Jq.Parser
+import           Jq.Expr
+import           Jq.Parser
 import           Generators
 
 shouldParseAs :: Text -> Expr -> Spec


### PR DESCRIPTION
Create property tests to catch the differences between the Haskell representation of `Scientific` numbers and the jq representation.

Cases covered:

- Integers with an arbitrary magnitude
```
0
1
1000
734257894365982734695234
```

- Integers with arbitrary signs
```
-0
-1
-734257894365982734695234
```

- Fractionals with an arbitrary magnitude and an arbitrary fraction
```
1.0
2.5
5555555555555555555555555.0
0.1
0.14159
0.5555555555555555555555555
5555555555555555555555555.5555555555555555555555555
```

- Fractionals with optional integer/fractional part
```
0.
.0
1.
.5
.5555555555555555555555555
5555555555555555555555555.
-0.
-.0
-1.
-.5
-.5555555555555555555555555
-5555555555555555555555555.
```

- Numbers with an exponent
```
...e0
...E0
...e1
...E1
...e10
...E10
...e+0
...E+0
...e-0
...E-0
...e+50
...E+500
...e-5000
```

Range on integers: `-10^309 <-> 10^309`
Range on exponents `-10^(1e16) <-> 10^(1e16)`

Closes #5.