### PR TITLE
[#31] Fix operator precedence

### DIFF
--- a/jq.cabal
+++ b/jq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 711a79f6a70bb5321b6b36abc94f17f61b9c767ed564ac72984be685760e8095
+-- hash: 2f5d17a2fab384600bb95ae6ad3b076b159080654ba8623850935538d02adc6e
 
 name:           jq
 version:        0.1.0
@@ -74,6 +74,7 @@ test-suite test
   other-modules:
       Generators
       JqParserTestSuite
+      ParseOperatorsTest
       ParserTest
       TestHelpers
       Paths_jq

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -80,11 +80,9 @@ exprOp = do
       , InfixN (ModAssign         <$ sym "%=")
       , InfixN (AlternativeAssign <$ sym "//=")
       ]
-    , [ InfixR (Alternative       <$ sym "//") ] -- 2
-    ] ++ (if allowComma
-          then [[InfixL (Comma <$ sym ",")]]     -- 1
-          else []) ++
-    [ [ InfixR  (Pipe  <$ sym "|") ] ]           -- 0
+    , [ InfixR (Alternative       <$ sym "//") ]     -- 2
+    ] ++ ([[InfixL (Comma <$ sym ",")] | allowComma] -- 1
+      ++ [ [ InfixR  (Pipe  <$ sym "|") ] ]          -- 0
     )
 
 term :: Parser Expr

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -55,13 +55,23 @@ exprOp :: Parser Expr
 exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
-    [ [ Prefix (Neg   <$ sym "-") ]
-    , [ InfixR (Pipe  <$ sym "|") ] ]
-    ++ (if allowComma
-        then [ [ InfixL (Comma    <$ sym ",") ] ]
-        else []) ++
-    [ [ InfixR (Alternative       <$ sym "//") ]
-    , [ InfixN (Assign            <$ sym "=")
+    [ [ Postfix (Optional <$ sym "?") ]          -- 10
+    , [ Prefix  (Neg      <$ sym "-") ]          -- 9
+    , [ InfixL  (Mult     <$ sym "*")            -- 8
+      , InfixL  (Div      <$ sym "/")
+      , InfixL  (Mod      <$ sym "%") ]
+    , [ InfixL  (Plus     <$ sym "+")            -- 7
+      , InfixL  (Minus    <$ sym "-") ]
+    , [ InfixN (Eq  <$ sym "==")                 -- 6
+      , InfixN (Neq <$ sym "!=")
+      , InfixN (Leq <$ sym "<=")
+      , InfixN (Geq <$ sym ">=")
+      , InfixN (Lt  <$ sym "<")
+      , InfixN (Gt  <$ sym ">")
+      ]
+    , [ InfixL (And <$ sym "and") ]              -- 5
+    , [ InfixL (Or  <$ sym "or") ]               -- 4
+    , [ InfixN (Assign            <$ sym "=")    -- 3
       , InfixN (UpdateAssign      <$ sym "|=")
       , InfixN (PlusAssign        <$ sym "+=")
       , InfixN (MinusAssign       <$ sym "-=")
@@ -70,23 +80,12 @@ exprOp = do
       , InfixN (ModAssign         <$ sym "%=")
       , InfixN (AlternativeAssign <$ sym "//=")
       ]
-    , [ InfixL (Or    <$ sym "or") ]
-    , [ InfixL (And   <$ sym "and") ]
-    , [ InfixN (Eq    <$ sym "==")
-      , InfixN (Neq   <$ sym "!=")
-      , InfixN (Leq   <$ sym "<=")
-      , InfixN (Geq   <$ sym ">=")
-      , InfixN (Lt    <$ sym "<")
-      , InfixN (Gt    <$ sym ">")
-      ]
-    , [ InfixL (Plus  <$ sym "+")
-      , InfixL (Minus <$ sym "-")
-      ]
-    , [ InfixL (Mult  <$ sym "*")
-      , InfixL (Div   <$ sym "/")
-      , InfixL (Mod   <$ sym "%")
-      ]
-    ])
+    , [ InfixR (Alternative       <$ sym "//") ] -- 2
+    ] ++ (if allowComma
+          then [[InfixL (Comma <$ sym ",")]]     -- 1
+          else []) ++
+    [ [ InfixR  (Pipe  <$ sym "|") ] ]           -- 0
+    )
 
 term :: Parser Expr
 term = asum
@@ -124,7 +123,6 @@ suffixes e =
   where
     suffix = asum [ dotAfter
                   , bracketAfter
-                  , questionAfter
                   ]
 
     dotAfter = dot *> asum
@@ -139,8 +137,6 @@ suffixes e =
           , pure (IndexAfter e i) ]                              -- e[i]
       , pure (ValueIterator e)                                   -- e[]
       ]
-
-    questionAfter = sym "?" $> Optional e
 
 funcDef :: Parser Expr
 funcDef = label "funcDef" $

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module ParseOperatorsTest where
+
+import           Data.Char (chr, isHexDigit)
+import           Data.Foldable (for_)
+import qualified Data.Text as Text
+import           Data.Text (Text)
+import           Data.Text.Read (hexadecimal)
+import           Data.Void
+import           Control.Monad (forM_)
+
+import           Hedgehog hiding (Var)
+import           Test.Hspec.Megaparsec
+import           Test.Tasty.Hspec
+import           Text.Megaparsec (parse, ParseErrorBundle)
+import           Text.RawString.QQ
+import           Text.Read (readEither)
+
+import           Jq.Expr
+import           Jq.Parser
+import           Generators
+import           TestHelpers
+
+spec_OperatorAssociativity :: Spec
+spec_OperatorAssociativity = do
+  describe "associative operators" $ do
+    "a | b | c" `shouldParseAs` Pipe a (Pipe b c)                  -- right
+    "a , b , c" `shouldParseAs` Comma (Comma a b) c                -- left
+    "a // b // c" `shouldParseAs` Alternative a (Alternative b c)  -- right
+
+  describe "non-associative assignment operators" $ do
+    forM_ (Text.words "= |= += -= *= /= %= //=") $ \op ->
+      let s = "a " <> op <> " b " <> op <> " c"
+      in it ("%%FAIL: " ++ Text.unpack s) $ parseExpr `shouldFailOn` s
+
+  describe "more associative operators" $ do
+    "a or b or c" `shouldParseAs` Or (Or a b) c      -- left
+    "a and b and c" `shouldParseAs` And (And a b) c  -- left
+
+  describe "more non-associative operators" $ do
+    forM_ (Text.words "== != < > <= >=") $ \op ->
+      let s = "a " <> op <> " b " <> op <> " c"
+      in it ("%%FAIL: " ++ Text.unpack s) $ parseExpr `shouldFailOn` s
+
+  describe "more associative operators" $ do
+    "a + b + c" `shouldParseAs` Plus (Plus a b) c    -- left
+    "a - b - c" `shouldParseAs` Minus (Minus a b) c  -- left
+    "a * b * c" `shouldParseAs` Mult (Mult a b) c    -- left
+    "a / b / c" `shouldParseAs` Div (Div a b) c      -- left
+    "a % b % c" `shouldParseAs` Mod (Mod a b) c      -- left
+
+  where
+    a = FilterCall "a" Nothing
+    b = FilterCall "b" Nothing
+    c = FilterCall "c" Nothing
+
+spec_OperatorPrecedence :: Spec
+spec_OperatorPrecedence = do
+  describe ", binds tighter than |" $ do
+    "a | b , c" `shouldParseAs` Pipe a (Comma b c)
+    "a , b | c" `shouldParseAs` Pipe (Comma a b) c
+
+  describe "// binds tighter than | ," $ do
+    "a // b | c" `shouldParseAs` Pipe (Alternative a b) c
+    "a | b // c" `shouldParseAs` Pipe a (Alternative b c)
+    "a // b , c" `shouldParseAs` Comma (Alternative a b) c
+    "a , b // c" `shouldParseAs` Comma a (Alternative b c)
+
+  describe "non-associative assignment operators bind tighter than | , //" $ do
+    -- -- The following tests are generalized for all assignment operators:
+    -- "a = b | c" `shouldParseAs` Pipe (Assign a b) c
+    -- "a | b = c" `shouldParseAs` Pipe a (Assign b c)
+    -- "a = b , c" `shouldParseAs` Comma (Assign a b) c
+    -- "a , b = c" `shouldParseAs` Comma a (Assign b c)
+    -- "a = b // c" `shouldParseAs` Alternative (Assign a b) c
+    -- "a // b = c" `shouldParseAs` Alternative a (Assign b c)
+
+    forM_ assignmentOperators $ \(op, exprOp) ->
+      forM_ lowPrecOperators $ \(lowOp, lowExprOp) -> do
+        ("a " <> op <> " b " <> lowOp <> " c") `shouldParseAs` lowExprOp (exprOp a b) c
+        ("a " <> lowOp <> " b " <> op <> " c") `shouldParseAs` lowExprOp a (exprOp b c)
+
+    -- TODO: and/or bind tighter than the operators above
+
+    describe "'and' binds tighter than 'or'" $ do
+      "a and b or c" `shouldParseAs` Or (And a b) c
+      "a or b and c" `shouldParseAs` Or a (And b c)
+
+    -- TODO: comparison operators bind tighter than the operators above
+    -- TODO: * / % bind tighter than + - and the other operators above
+
+  where
+    a = FilterCall "a" Nothing
+    b = FilterCall "b" Nothing
+    c = FilterCall "c" Nothing
+
+    assignmentOperators =
+      [ ("=",   Assign)
+      , ("|=",  UpdateAssign)
+      , ("+=",  PlusAssign)
+      , ("-=",  MinusAssign)
+      , ("*=",  MultAssign)
+      , ("/=",  DivAssign)
+      , ("%=",  ModAssign)
+      , ("//=", AlternativeAssign)
+      ]
+
+    lowPrecOperators =
+      [ ("|", Pipe)
+      , (",", Comma)
+      , ("//", Alternative) ]

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
 
 module ParseOperatorsTest where
 
@@ -23,6 +22,11 @@ import           Jq.Parser
 import           Generators
 import           TestHelpers
 
+a, b, c :: Expr
+a = FilterCall "a" Nothing
+b = FilterCall "b" Nothing
+c = FilterCall "c" Nothing
+
 spec_OperatorAssociativity :: Spec
 spec_OperatorAssociativity = do
   describe "associative operators" $ do
@@ -30,16 +34,16 @@ spec_OperatorAssociativity = do
     "a , b , c" `shouldParseAs` Comma (Comma a b) c                -- left
     "a // b // c" `shouldParseAs` Alternative a (Alternative b c)  -- right
 
-  describe "non-associative assignment operators" $ do
+  describe "non-associative assignment operators" $
     forM_ (Text.words "= |= += -= *= /= %= //=") $ \op ->
       let s = "a " <> op <> " b " <> op <> " c"
       in it ("%%FAIL: " ++ Text.unpack s) $ parseExpr `shouldFailOn` s
 
-  describe "more associative operators" $ do
+  describe "more associative operators" $
     "a or b or c" `shouldParseAs` Or (Or a b) c      -- left
     "a and b and c" `shouldParseAs` And (And a b) c  -- left
 
-  describe "more non-associative operators" $ do
+  describe "more non-associative operators" $
     forM_ (Text.words "== != < > <= >=") $ \op ->
       let s = "a " <> op <> " b " <> op <> " c"
       in it ("%%FAIL: " ++ Text.unpack s) $ parseExpr `shouldFailOn` s
@@ -50,11 +54,6 @@ spec_OperatorAssociativity = do
     "a * b * c" `shouldParseAs` Mult (Mult a b) c    -- left
     "a / b / c" `shouldParseAs` Div (Div a b) c      -- left
     "a % b % c" `shouldParseAs` Mod (Mod a b) c      -- left
-
-  where
-    a = FilterCall "a" Nothing
-    b = FilterCall "b" Nothing
-    c = FilterCall "c" Nothing
 
 spec_OperatorPrecedence :: Spec
 spec_OperatorPrecedence = do
@@ -92,10 +91,6 @@ spec_OperatorPrecedence = do
     -- TODO: * / % bind tighter than + - and the other operators above
 
   where
-    a = FilterCall "a" Nothing
-    b = FilterCall "b" Nothing
-    c = FilterCall "c" Nothing
-
     assignmentOperators =
       [ ("=",   Assign)
       , ("|=",  UpdateAssign)


### PR DESCRIPTION
Some precedence tests are omitted in lack of better abstraction.

[#31] is kept open until all associativity/precedence tests pass.

They do not because of #28.