### PR TITLE
Fix keywords and operators being eaten to aggressively

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Right (FuncDef "map" [FilterParam "f"]
 
 ## Status
 
-Parser: 181 out of 580 tests failed.
+Parser: 128 out of 639 tests failed.
 
 ## Contributing
 

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -91,11 +91,11 @@ term = asum
   , List    <$> list
   , Str     <$> string
   , BoolLit <$> bool
-  , NullLit <$ sym "null"
+  , NullLit <$ try (sym "null" >> notFollowedBy ident)
   , Paren   <$> parens expr
   , Var     <$> var
-  , NanLit  <$ sym "nan"
-  , InfLit  <$ sym "infinite"
+  , NanLit  <$ try (sym "nan" >> notFollowedBy ident)
+  , InfLit  <$ try (sym "infinite" >> notFollowedBy ident)
   , try (NumLit <$> number) <|> dotExpr
   , funcDef
   , filterCall

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -56,22 +56,22 @@ exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
     [ [ Postfix (Optional <$ sym "?") ]          -- 10
-    , [ Prefix  (Neg      <$ sym "-") ]          -- 9
-    , [ InfixL  (Mult     <$ sym "*")            -- 8
-      , InfixL  (Div      <$ sym "/")
-      , InfixL  (Mod      <$ sym "%") ]
-    , [ InfixL  (Plus     <$ sym "+")            -- 7
-      , InfixL  (Minus    <$ sym "-") ]
+    , [ Prefix  (Neg      <$ try (sym "-" >> notFollowedBy (sym "="))) ]          -- 9
+    , [ InfixL  (Mult     <$ try (sym "*" >> notFollowedBy (sym "=")))            -- 8
+      , InfixL  (Div      <$ try (sym "/" >> notFollowedBy (sym "=" <|> sym "/")))
+      , InfixL  (Mod      <$ try (sym "%" >> notFollowedBy (sym "="))) ]
+    , [ InfixL  (Plus     <$ try (sym "+" >> notFollowedBy (sym "=")))            -- 7
+      , InfixL  (Minus    <$ try (sym "-" >> notFollowedBy (sym "="))) ]
     , [ InfixN (Eq  <$ sym "==")                 -- 6
       , InfixN (Neq <$ sym "!=")
       , InfixN (Leq <$ sym "<=")
       , InfixN (Geq <$ sym ">=")
-      , InfixN (Lt  <$ sym "<")
-      , InfixN (Gt  <$ sym ">")
+      , InfixN (Lt  <$ try (sym "<" >> notFollowedBy (sym "=")))
+      , InfixN (Gt  <$ try (sym ">" >> notFollowedBy (sym "=")))
       ]
     , [ InfixL (And <$ sym "and") ]              -- 5
     , [ InfixL (Or  <$ sym "or") ]               -- 4
-    , [ InfixN (Assign            <$ sym "=")    -- 3
+    , [ InfixN (Assign            <$ try (sym "=" >> notFollowedBy (sym "=")))    -- 3
       , InfixN (UpdateAssign      <$ sym "|=")
       , InfixN (PlusAssign        <$ sym "+=")
       , InfixN (MinusAssign       <$ sym "-=")
@@ -82,7 +82,7 @@ exprOp = do
       ]
     , [ InfixR (Alternative       <$ sym "//") ]     -- 2
     ] ++ [[InfixL (Comma <$ sym ",")] | allowComma] -- 1
-      ++ [ [ InfixR  (Pipe  <$ sym "|") ] ]          -- 0
+      ++ [ [ InfixR  (Pipe  <$ try (sym "|" >> notFollowedBy (sym "="))) ] ]          -- 0
     )
 
 term :: Parser Expr

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -27,6 +27,39 @@ a = FilterCall "a" Nothing
 b = FilterCall "b" Nothing
 c = FilterCall "c" Nothing
 
+spec_OperatorsParse :: Spec
+spec_OperatorsParse = do
+  describe "binary operators parse correctly" $ do
+    "a * b" `shouldParseAs` Mult a b
+    "a / b" `shouldParseAs` Div a b
+    "a % b" `shouldParseAs` Mod a b
+
+    "a + b" `shouldParseAs` Plus a b
+    "a - b" `shouldParseAs` Minus a b
+
+    "a == b" `shouldParseAs` Eq a b
+    "a != b" `shouldParseAs` Neq a b
+    "a <= b" `shouldParseAs` Leq a b
+    "a >= b" `shouldParseAs` Geq a b
+    "a < b" `shouldParseAs` Lt a b
+    "a > b" `shouldParseAs` Gt a b
+
+    "a and b" `shouldParseAs` And a b
+    "a or b" `shouldParseAs` Or a b
+
+    "a = b" `shouldParseAs` Assign a b
+    "a |= b" `shouldParseAs` UpdateAssign a b
+    "a += b" `shouldParseAs` PlusAssign a b
+    "a -= b" `shouldParseAs` MinusAssign a b
+    "a *= b" `shouldParseAs` MultAssign a b
+    "a /= b" `shouldParseAs` DivAssign a b
+    "a %= b" `shouldParseAs` ModAssign a b
+    "a //= b" `shouldParseAs` AlternativeAssign a b
+
+    "a // b" `shouldParseAs` Alternative a b
+    "a , b" `shouldParseAs` Comma a b
+    "a | b" `shouldParseAs` Pipe a b
+
 spec_OperatorAssociativity :: Spec
 spec_OperatorAssociativity = do
   describe "associative operators" $ do

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -3,6 +3,8 @@
 
 module ParserTest where
 
+import           Control.Monad
+
 import           Data.Char (chr, isHexDigit)
 import           Data.Foldable (for_)
 import qualified Data.Text as Text
@@ -94,9 +96,9 @@ spec_FuncDef =
 spec_Keywords :: Spec
 spec_Keywords = do
   describe "Maximal munch and keywords" $ do
-    "nulls" `shouldParseAs` FilterCall "nulls" Nothing
-    "nano" `shouldParseAs` FilterCall "nano" Nothing
-    "infinites" `shouldParseAs` FilterCall "infinites" Nothing
+    forM_ keywords $ \kw -> do
+      (kw <> "s") `shouldParseAs` FilterCall (kw <> "s") Nothing
+      ("s" <> kw) `shouldParseAs` FilterCall ("s" <> kw) Nothing
 
 spec_FilterCall :: Spec
 spec_FilterCall =


### PR DESCRIPTION
Fixes #28

Fix parser consumes prefixes as complete grammar pieces
Since parentheses and whitespaces can't appear inside identifiers, that bug might be fixed by explicit postfix checking