### PR TITLE
Feature/destructuring alternative operator

### DIFF
--- a/src/Jq/Expr.hs
+++ b/src/Jq/Expr.hs
@@ -43,6 +43,7 @@ data AbstractExpr n
     | Or !Expr !Expr                 -- 'or'
     | And !Expr !Expr                -- 'and'
     | Alternative !Expr !Expr        -- '//'
+    | AltDestruct !Expr !Expr           -- '?//'
     | AlternativeAssign !Expr !Expr  -- '//='
     | UpdateAssign !Expr !Expr       -- '|='
     | Pipe !Expr !Expr               -- '|'
@@ -63,7 +64,6 @@ data AbstractExpr n
     | Gt !Expr !Expr                 -- '>'
     | Leq !Expr !Expr                -- '<='
     | Geq !Expr !Expr                -- '>='
-    | AltDestr !Expr !Expr           -- '?//'
 
       -- Prefix/postfix
     | Optional !Expr                 -- suffix '?'

--- a/src/Jq/Expr.hs
+++ b/src/Jq/Expr.hs
@@ -63,6 +63,7 @@ data AbstractExpr n
     | Gt !Expr !Expr                 -- '>'
     | Leq !Expr !Expr                -- '<='
     | Geq !Expr !Expr                -- '>='
+    | AltDestr !Expr !Expr           -- '?//'
 
       -- Prefix/postfix
     | Optional !Expr                 -- suffix '?'

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -55,7 +55,8 @@ exprOp :: Parser Expr
 exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
-    [ [ Postfix (Optional <$ sym "?") ]          -- 10
+    [ [ InfixN  (AltDestr <$ sym "?//") ]        -- 11
+    , [ Postfix (Optional <$ try (sym "?" >> (notFollowedBy $ sym "/"))) ] -- 10
     , [ Prefix  (Neg      <$ try (sym "-" >> notFollowedBy (sym "="))) ]          -- 9
     , [ InfixL  (Mult     <$ try (sym "*" >> notFollowedBy (sym "=")))            -- 8
       , InfixL  (Div      <$ try (sym "/" >> notFollowedBy (sym "=" <|> sym "/")))

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -56,7 +56,7 @@ exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
     [ [ InfixN  (AltDestr <$ sym "?//") ]        -- 11
-    , [ Postfix (Optional <$ try (sym "?" >> (notFollowedBy $ sym "/"))) ] -- 10
+    , [ Postfix (Optional <$ try (sym "?" >> notFollowedBy (sym "/"))) ] -- 10
     , [ Prefix  (Neg      <$ try (sym "-" >> notFollowedBy (sym "="))) ]          -- 9
     , [ InfixL  (Mult     <$ try (sym "*" >> notFollowedBy (sym "=")))            -- 8
       , InfixL  (Div      <$ try (sym "/" >> notFollowedBy (sym "=" <|> sym "/")))

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -55,7 +55,7 @@ exprOp :: Parser Expr
 exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
-    [ [ InfixN  (AltDestr <$ sym "?//") ]        -- 11
+    [ [ InfixN (AltDestruct  <$ sym "?//") ]        -- 11
     , [ Postfix (Optional <$ try (sym "?" >> notFollowedBy (sym "/"))) ] -- 10
     , [ Prefix  (Neg      <$ try (sym "-" >> notFollowedBy (sym "="))) ]          -- 9
     , [ InfixL  (Mult     <$ try (sym "*" >> notFollowedBy (sym "=")))            -- 8

--- a/src/Jq/Parser.hs
+++ b/src/Jq/Parser.hs
@@ -56,7 +56,7 @@ exprOp = do
   allowComma <- asks envAllowComma
   makeExprParser term (
     [ [ InfixN (AltDestruct  <$ sym "?//") ]        -- 11
-    , [ Postfix (Optional <$ try (sym "?" >> notFollowedBy (sym "/"))) ] -- 10
+    , [ Postfix (Optional <$ try (sym "?" >> notFollowedBy (sym "//"))) ] -- 10
     , [ Prefix  (Neg      <$ try (sym "-" >> notFollowedBy (sym "="))) ]          -- 9
     , [ InfixL  (Mult     <$ try (sym "*" >> notFollowedBy (sym "=")))            -- 8
       , InfixL  (Div      <$ try (sym "/" >> notFollowedBy (sym "=" <|> sym "/")))

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -77,7 +77,7 @@ spec_OperatorAssociativity = do
     "a and b and c" `shouldParseAs` And (And a b) c  -- left
 
   describe "more non-associative operators" $
-    forM_ (Text.words "== != < > <= >=") $ \op ->
+    forM_ (Text.words "== != < > <= >= ?//") $ \op ->
       let s = "a " <> op <> " b " <> op <> " c"
       in it ("%%FAIL: " ++ Text.unpack s) $ parseExpr `shouldFailOn` s
 
@@ -123,6 +123,11 @@ spec_OperatorPrecedence = do
     -- TODO: comparison operators bind tighter than the operators above
     -- TODO: * / % bind tighter than + - and the other operators above
 
+    describe "'?//' is parsed if it's possible" $ do
+      "a ?// b" `shouldParseAs` AltDestr a b
+      "a ?" `shouldParseAs` Optional a
+
+  
   where
     assignmentOperators =
       [ ("=",   Assign)

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -123,9 +123,11 @@ spec_OperatorPrecedence = do
     -- TODO: comparison operators bind tighter than the operators above
     -- TODO: * / % bind tighter than + - and the other operators above
 
-    describe "'?//' is parsed if it's possible" $ do
+    describe "alternative destructure '?//' is parsed if it's possible" $ do
       "a ?// b" `shouldParseAs` AltDestr a b
       "a ?" `shouldParseAs` Optional a
+      "null? / 4" `shouldParseAs` Div (Optional NullLit) (NumLit 4)
+      "null ?/ 4" `shouldParseAs` Div (Optional NullLit) (NumLit 4)
 
   where
     assignmentOperators =

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -127,7 +127,6 @@ spec_OperatorPrecedence = do
       "a ?// b" `shouldParseAs` AltDestr a b
       "a ?" `shouldParseAs` Optional a
 
-  
   where
     assignmentOperators =
       [ ("=",   Assign)

--- a/test/ParseOperatorsTest.hs
+++ b/test/ParseOperatorsTest.hs
@@ -124,7 +124,7 @@ spec_OperatorPrecedence = do
     -- TODO: * / % bind tighter than + - and the other operators above
 
     describe "alternative destructure '?//' is parsed if it's possible" $ do
-      "a ?// b" `shouldParseAs` AltDestr a b
+      "a ?// b" `shouldParseAs` AltDestruct a b
       "a ?" `shouldParseAs` Optional a
       "null? / 4" `shouldParseAs` Div (Optional NullLit) (NumLit 4)
       "null ?/ 4" `shouldParseAs` Div (Optional NullLit) (NumLit 4)


### PR DESCRIPTION
#32 
Extended `Expr` with `AlternativeDestructure` constructor.
Extended operator table in Parser with this operator.
An overlap between the `?` postfix operator and `?//` is resolved in a similar way as it was in #34 